### PR TITLE
Fix NPE in getCurrentPose method due to missing model

### DIFF
--- a/src/main/java/mchorse/emoticons/skin_n_bones/api/metamorph/AnimatedMorph.java
+++ b/src/main/java/mchorse/emoticons/skin_n_bones/api/metamorph/AnimatedMorph.java
@@ -352,6 +352,11 @@ public class AnimatedMorph extends AbstractMorph implements IBodyPartProvider, I
 
         this.initiateAnimator();
 
+        if (this.animator.animation == null)
+        {
+            return this.pose == null ? new AnimatedPose() : this.pose.clone();
+        }
+
         AnimationMesh mesh = this.animator.animation.meshes.get(0);
         BOBJArmature original = mesh.getArmature();
         BOBJArmature armature = this.animator.animator.useArmature(original);


### PR DESCRIPTION
I know emoticons are not like snb where the user can add the model themselves, but still, to make sure the logic is correct submit this PR